### PR TITLE
Document Codex MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ claude plugin install enzyme
 
 Inside Claude Code, invoke `/enzyme` to explore your vault by concept.
 
-### Codex and other MCP clients
+### Codex, OpenCode, and other MCP clients
 
-Enzyme ships a stdio MCP server that works with MCP-compatible clients, including Codex, Claude Desktop, and Cursor. Register `enzyme mcp` in your client's MCP configuration:
+Enzyme ships a stdio MCP server that works with MCP-compatible clients, including Codex, OpenCode, Claude Desktop, and Cursor. Register `enzyme mcp` in your client's MCP configuration:
 
 ```bash
 enzyme mcp
@@ -57,7 +57,7 @@ cd /path/to/your/vault    # any folder of markdown files
 enzyme init                # compiles concept graph — under 20s for 1k docs
 ```
 
-In Claude Code, use `/enzyme`. In Codex and other MCP clients, use the exposed Enzyme MCP tools directly.
+In Claude Code, use `/enzyme`. In Codex, OpenCode, and other MCP clients, use the exposed Enzyme MCP tools directly.
 
 ## What it does
 

--- a/README.md
+++ b/README.md
@@ -29,19 +29,23 @@ On macOS you can also use Homebrew:
 brew install jshph/enzyme/enzyme-cli
 ```
 
-Then add the Claude Code plugin:
+Then configure your client:
+
+### Claude Code plugin
 
 ```bash
 claude plugin marketplace add jshph/enzyme
 claude plugin install enzyme
 ```
 
-### MCP server
+Inside Claude Code, invoke `/enzyme` to explore your vault by concept.
 
-If you prefer MCP over the plugin, Enzyme ships a stdio MCP server that works with any MCP-compatible client (Claude Desktop, Cursor, etc):
+### Codex and other MCP clients
+
+Enzyme ships a stdio MCP server that works with MCP-compatible clients, including Codex, Claude Desktop, and Cursor. Register `enzyme mcp` in your client's MCP configuration:
 
 ```bash
-claude mcp add enzyme -- enzyme mcp
+enzyme mcp
 ```
 
 The MCP server exposes `init`, `petri`, `catalyze`, and `status` tools — you can initialize and explore your vault entirely from the client without running CLI commands separately.
@@ -53,7 +57,7 @@ cd /path/to/your/vault    # any folder of markdown files
 enzyme init                # compiles concept graph — under 20s for 1k docs
 ```
 
-Inside Claude Code, invoke `/enzyme` to explore your vault by concept.
+In Claude Code, use `/enzyme`. In Codex and other MCP clients, use the exposed Enzyme MCP tools directly.
 
 ## What it does
 


### PR DESCRIPTION
## Summary
- reframe setup docs around client configuration instead of only the Claude plugin
- add a Codex and MCP-compatible client section that points users at the `enzyme mcp` server
- clarify quick-start usage for Claude Code versus Codex-style MCP tool access